### PR TITLE
Fix production ML model validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ worker/target/
 coverage/
 test-results/
 playwright-report/
+/.playwright-cli/
+/output/
 
 # misc
 .DS_Store

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -36,11 +36,22 @@ test.describe('Core Game Functionality', () => {
   });
 
   test('can start watch mode and see AI vs AI', async ({ page }) => {
+    const mlFailures: string[] = [];
+    let modelRequests = 0;
+    page.on('console', message => {
+      if (message.type() === 'error' && message.text().includes('AI worker ml request failed')) {
+        mlFailures.push(message.text());
+      }
+    });
+    page.on('request', request => {
+      if (new URL(request.url()).pathname === '/ml-weights.json.gz') modelRequests += 1;
+    });
+
     await startGame(page, 'watch');
     await expect(page.getByTestId('game-status-text')).toContainText("'s turn");
-    // In watch mode, AI should make moves automatically
-    await page.waitForTimeout(2000);
+    await expect.poll(() => modelRequests, { timeout: 5000 }).toBeGreaterThan(0);
     await expect(page.getByTestId('game-status-text')).not.toBeEmpty();
+    expect(mlFailures).toEqual([]);
   });
 });
 

--- a/src/lib/__tests__/ai-protocol.test.ts
+++ b/src/lib/__tests__/ai-protocol.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   AIPositionSchema,
   AIWorkerRequestSchema,
@@ -119,6 +121,14 @@ describe('AI protocol', () => {
         },
       }).success
     ).toBe(false);
+  });
+
+  it('accepts the exact production model artifact', () => {
+    const artifact = JSON.parse(
+      readFileSync(resolve('public/ml-weights.json'), 'utf8')
+    ) as unknown;
+
+    expect(MLWeightsSchema.safeParse(artifact).success).toBe(true);
   });
 
   it('creates the narrow position contract without board or history data', () => {

--- a/src/lib/ai-protocol.ts
+++ b/src/lib/ai-protocol.ts
@@ -66,6 +66,30 @@ export function toWasmGameState(position: AIPosition) {
 
 const VALUE_WEIGHT_COUNT = 81_921;
 const POLICY_WEIGHT_COUNT = 82_119;
+const HiddenSizesSchema = z.tuple([
+  z.literal(256),
+  z.literal(128),
+  z.literal(64),
+  z.literal(32),
+]);
+const FlatNetworkConfigSchema = z.object({
+  input_size: z.literal(150),
+  hidden_sizes: HiddenSizesSchema,
+  value_output_size: z.literal(1),
+  policy_output_size: z.literal(7),
+});
+const DualNetworkConfigSchema = z.object({
+  value_network: z.object({
+    input_size: z.literal(150),
+    hidden_sizes: HiddenSizesSchema,
+    output_size: z.literal(1),
+  }),
+  policy_network: z.object({
+    input_size: z.literal(150),
+    hidden_sizes: HiddenSizesSchema,
+    output_size: z.literal(7),
+  }),
+});
 
 export const MLWeightsSchema = z.object({
   value_weights: z.array(z.number().finite()).length(VALUE_WEIGHT_COUNT),
@@ -78,12 +102,7 @@ export const MLWeightsSchema = z.object({
     seed: z.number().int(),
     best_validation_loss: z.number().finite().nonnegative(),
   }),
-  network_config: z.object({
-    input_size: z.literal(150),
-    hidden_sizes: z.tuple([z.literal(256), z.literal(128), z.literal(64), z.literal(32)]),
-    value_output_size: z.literal(1),
-    policy_output_size: z.literal(7),
-  }),
+  network_config: z.union([FlatNetworkConfigSchema, DualNetworkConfigSchema]),
 });
 
 export type MLWeights = z.infer<typeof MLWeightsSchema>;


### PR DESCRIPTION
## What changed

- accepts both canonical flat and deployed dual-network metadata shapes while retaining exact architecture checks
- validates the checked-in production model in the unit suite
- makes watch-mode E2E prove that the model is requested without an ML worker failure
- ignores local browser-verification artifacts

## Root cause

The provenance tooling normalized both network metadata shapes, but the browser runtime accepted only the flat form. The deployed v5 artifact uses the dual-network form, so validation failed and the game used its deterministic fallback.

## Verification

- `npm run check`
- 156 Vitest tests
- 102 Rust unit tests plus integrations
- 21 Playwright tests across Chromium and WebKit
- live browser reproduction confirmed before the fix