### PR TITLE
Allow Cloudflare release propagation in smoke test

### DIFF
--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -8,14 +8,18 @@ const checks = [
   { path: '/wasm/rgou_ai_worker_bg.wasm', type: 'application/wasm' },
   { path: '/ml-weights.json.gz', type: 'application/gzip' },
 ];
+const propagationAttempts = 20;
 
 const pause = () => new Promise(resolve => setTimeout(resolve, 3_000));
 
-async function waitFor(check) {
+export async function waitFor(
+  check,
+  { attempts = propagationAttempts, fetchImpl = fetch, pauseImpl = pause } = {}
+) {
   let detail = 'No response';
-  for (let attempt = 0; attempt < 10; attempt += 1) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      const response = await fetch(`${origin}${check.path}`, {
+      const response = await fetchImpl(`${origin}${check.path}`, {
         cache: 'no-store',
         signal: AbortSignal.timeout(10_000),
       });
@@ -33,7 +37,7 @@ async function waitFor(check) {
     } catch (error) {
       detail = String(error);
     }
-    if (attempt < 9) await pause();
+    if (attempt < attempts - 1) await pauseImpl();
   }
   throw new Error(`Smoke check failed for ${check.path}: ${detail}`);
 }

--- a/scripts/smoke-production.test.mjs
+++ b/scripts/smoke-production.test.mjs
@@ -6,6 +6,7 @@ import {
   checkConfiguredCanonicalRedirects,
   getConfiguredAliases,
   runProductionSmokeCli,
+  waitFor,
 } from './smoke-production.mjs';
 
 const expectedAliases = [
@@ -79,6 +80,23 @@ test('does not pass when the deployment declares no aliases', async () => {
     checkConfiguredCanonicalRedirects('[assets]\ndirectory = "./out/client"'),
     /wrangler\.toml declares no aliases/
   );
+});
+
+test('allows time for a release identity to propagate', async () => {
+  let attempts = 0;
+
+  await waitFor(
+    { path: '/healthz', type: 'application/json', includes: 'current-release' },
+    {
+      fetchImpl: async () => {
+        attempts += 1;
+        return Response.json({ release: attempts > 10 ? 'current-release' : 'previous-release' });
+      },
+      pauseImpl: async () => undefined,
+    }
+  );
+
+  assert.equal(attempts, 11);
 });
 
 test('the CLI exits cleanly with the smoke result', async () => {


### PR DESCRIPTION
## Summary

- extend the bounded production-smoke propagation allowance from about 27 seconds to about 57 seconds
- make the polling function injectable and directly test delayed release identity propagation

## Root cause

Cloudflare served the newly deployed assets before every edge returned the new health-check release SHA. The first deployment passed seconds after CI exhausted its ten polls.

## Validation

- npm run test:smoke-production
- npm run lint
- npm run type-check
- independent live smoke against merge release 218329f