### PR TITLE
Precache lazy assets for offline play

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,17 +82,17 @@ Components may contain display decisions and transient animation state. Reusable
 
 ### Data, privacy, and delivery patterns
 
-| Pattern                     | Invariant                                                                                                      | Implementation                                                                      |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Local-first persistence     | In-progress games, settings, and personal statistics remain in local storage and are validated when restored.  | Zustand persistence plus `persist-storage.ts`                                       |
-| Data minimization           | Analytics contain only the dimensions required for aggregate product questions.                                | `usage.ts`; startup removes the retired `rgou-player-id` key.                       |
-| Best-effort domain events   | Telemetry observes lifecycle transitions but never participates in them.                                       | `game_started` and `game_completed` via `/api/usage`                                |
-| Front controller            | The edge Worker owns canonical-host policy and API routing before delegating to static assets.                 | `src/worker.ts`, `canonical-host.ts`                                                |
-| Tiered offline precache     | Required shell failure aborts installation; large AI assets are optional; health and API routes stay online.   | generated service worker plus its Node and browser contract tests                   |
-| Intentional code splitting  | Optional or heavy UI infrastructure does not inflate the initial application chunk.                            | Lazy diagnostics and Sentry imports; the animation vendor group in `vite.config.ts` |
-| Serialized verified release | Only the newest run for a ref deploys; production reports and smoke-tests the exact commit identity.           | workflow concurrency, `/healthz`, `X-App-Release`, production smoke test            |
-| Supply-chain gate           | Known high-severity advisories block deployment; update automation cannot silently change executable CI code.  | Audits, lockfiles, immutable action SHAs, Dependabot, and GitHub code scanning      |
-| Diagram as code             | Relationship-heavy views have reviewable DOT sources, committed renders, one question each, and CI validation. | `docs/diagrams/`, `scripts/render-diagrams.mjs`, `scripts/check-diagrams.mjs`       |
+| Pattern                     | Invariant                                                                                                                            | Implementation                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Local-first persistence     | In-progress games, settings, and personal statistics remain in local storage and are validated when restored.                        | Zustand persistence plus `persist-storage.ts`                                       |
+| Data minimization           | Analytics contain only the dimensions required for aggregate product questions.                                                      | `usage.ts`; startup removes the retired `rgou-player-id` key.                       |
+| Best-effort domain events   | Telemetry observes lifecycle transitions but never participates in them.                                                             | `game_started` and `game_completed` via `/api/usage`                                |
+| Front controller            | The edge Worker owns canonical-host policy and API routing before delegating to static assets.                                       | `src/worker.ts`, `canonical-host.ts`                                                |
+| Tiered offline precache     | The complete built application, including lazy chunks, is required; large AI assets are optional; health and API routes stay online. | generated service worker plus its Node and browser contract tests                   |
+| Intentional code splitting  | Optional or heavy UI infrastructure does not inflate the initial application chunk.                                                  | Lazy diagnostics and Sentry imports; the animation vendor group in `vite.config.ts` |
+| Serialized verified release | Only the newest run for a ref deploys; production reports and smoke-tests the exact commit identity.                                 | workflow concurrency, `/healthz`, `X-App-Release`, production smoke test            |
+| Supply-chain gate           | Known high-severity advisories block deployment; update automation cannot silently change executable CI code.                        | Audits, lockfiles, immutable action SHAs, Dependabot, and GitHub code scanning      |
+| Diagram as code             | Relationship-heavy views have reviewable DOT sources, committed renders, one question each, and CI validation.                       | `docs/diagrams/`, `scripts/render-diagrams.mjs`, `scripts/check-diagrams.mjs`       |
 
 ## Frontend structure
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,7 +27,7 @@ npm run build:rust-ai       # native Rust build
 npm run generate:sw         # service worker (CI commit SHA or local timestamp cache version)
 ```
 
-The production build keeps the application, animation runtime, and lazy error-monitoring code in separate chunks. Treat a new Vite chunk-size warning as a design signal; split the responsible boundary instead of raising the warning threshold.
+The production build keeps the application, animation runtime, and lazy error-monitoring code in separate chunks. Its final service-worker generation step precaches every built static asset so lazy chunks remain available offline. Treat a new Vite chunk-size warning as a design signal; split the responsible boundary instead of raising the warning threshold.
 
 ## Architecture diagrams
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run build:wasm-assets && npm run generate:sw && vite",
-    "build": "rm -rf out && npm run generate:sw && npm run build:wasm-assets && npm run type-check && vite build",
+    "build": "rm -rf out && npm run generate:sw && npm run build:wasm-assets && npm run type-check && vite build && node scripts/generate-sw.js --built",
     "start": "vite preview",
     "preview": "vite preview",
     "deploy": "npm run build && wrangler deploy --config out/rgou_main/wrangler.json",

--- a/scripts/generate-sw.js
+++ b/scripts/generate-sw.js
@@ -4,11 +4,31 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-export function createServiceWorkerSource(releaseId) {
-  const cacheVersion = `${releaseId}-v1.1.0`;
+export function findBuildAssets(assetDir) {
+  if (!assetDir || !fs.existsSync(assetDir)) return [];
+
+  const paths = [];
+  const visit = directory => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (!entry.name.endsWith('.map')) {
+        paths.push(`/assets/${path.relative(assetDir, entryPath).split(path.sep).join('/')}`);
+      }
+    }
+  };
+
+  visit(assetDir);
+  return paths.sort();
+}
+
+export function createServiceWorkerSource(releaseId, buildAssets = []) {
+  const cacheVersion = `${releaseId}-v1.2.0`;
   return `const CACHE_VERSION = '${cacheVersion}';
 const CACHE_NAME = \`royal-game-of-ur-\${CACHE_VERSION}\`;
 const OFFLINE_URL = '/offline';
+const BUILD_ASSETS = ${JSON.stringify(buildAssets, null, 2)};
 
 const REQUIRED_ASSETS = [
   '/',
@@ -36,7 +56,7 @@ self.addEventListener('install', event => {
         html.matchAll(/(?:src|href)=["'](\\/assets\\/[^"']+)["']/g),
         match => match[1]
       );
-      await cache.addAll([...new Set(shellAssets)]);
+      await cache.addAll([...new Set([...shellAssets, ...BUILD_ASSETS])]);
 
       const results = await Promise.allSettled(
         OPTIONAL_ASSETS.map(asset => cache.add(asset))
@@ -142,15 +162,25 @@ self.addEventListener('message', event => {
 export function generateServiceWorker({
   releaseId = process.env.GITHUB_SHA?.slice(0, 12) || `local-${Date.now()}`,
   publicDir = path.join(process.cwd(), 'public'),
+  assetDir,
 } = {}) {
-  const cacheVersion = `${releaseId}-v1.1.0`;
+  const cacheVersion = `${releaseId}-v1.2.0`;
   const swPath = path.join(publicDir, 'sw.js');
+  const buildAssets = findBuildAssets(assetDir);
 
   console.log('Generating service worker with cache version:', cacheVersion);
-  fs.writeFileSync(swPath, createServiceWorkerSource(releaseId));
+  fs.writeFileSync(swPath, createServiceWorkerSource(releaseId, buildAssets));
   console.log('Service worker generated successfully');
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  generateServiceWorker();
+  const built = process.argv.includes('--built');
+  generateServiceWorker(
+    built
+      ? {
+          publicDir: path.join(process.cwd(), 'out/client'),
+          assetDir: path.join(process.cwd(), 'out/client/assets'),
+        }
+      : undefined
+  );
 }

--- a/scripts/generate-sw.test.mjs
+++ b/scripts/generate-sw.test.mjs
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 import vm from 'node:vm';
-import { createServiceWorkerSource } from './generate-sw.js';
+import { createServiceWorkerSource, findBuildAssets } from './generate-sw.js';
 
-function installPromiseFor(cache, errors = []) {
+function installPromiseFor(cache, errors = [], buildAssets = []) {
   let installHandler;
   let installPromise;
   const self = {
@@ -14,7 +17,7 @@ function installPromiseFor(cache, errors = []) {
     location: { origin: 'https://gameofur.org' },
   };
 
-  vm.runInNewContext(createServiceWorkerSource('test-release'), {
+  vm.runInNewContext(createServiceWorkerSource('test-release', buildAssets), {
     URL,
     Response,
     caches: {
@@ -93,6 +96,43 @@ test('hashed application assets are part of the required offline shell', async (
     '/assets/index-123.css',
     '/assets/index-456.js',
   ]);
+});
+
+test('production precache includes lazy build chunks and excludes source maps', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rgou-sw-'));
+  const assetDir = path.join(root, 'assets');
+  fs.mkdirSync(path.join(assetDir, 'nested'), { recursive: true });
+  fs.writeFileSync(path.join(assetDir, 'index-123.js'), '');
+  fs.writeFileSync(path.join(assetDir, 'prod-456.js'), '');
+  fs.writeFileSync(path.join(assetDir, 'nested', 'worker-789.js'), '');
+  fs.writeFileSync(path.join(assetDir, 'prod-456.js.map'), '');
+
+  try {
+    const buildAssets = findBuildAssets(assetDir);
+    assert.deepEqual(buildAssets, [
+      '/assets/index-123.js',
+      '/assets/nested/worker-789.js',
+      '/assets/prod-456.js',
+    ]);
+
+    const addAllCalls = [];
+    const installPromise = installPromiseFor(
+      {
+        add: async () => undefined,
+        addAll: async assets => addAllCalls.push(Array.from(assets)),
+        match: async () =>
+          new Response('<script type="module" src="/assets/index-123.js"></script>'),
+        put: async () => undefined,
+      },
+      [],
+      buildAssets
+    );
+
+    await assert.doesNotReject(installPromise);
+    assert.deepEqual(addAllCalls[1], buildAssets);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('health and API requests bypass the cache', () => {


### PR DESCRIPTION
## What changed

- generate the production service worker after the client build
- precache every built static asset, including lazy Sentry and diagnostics chunks
- exclude source maps and retain optional handling for large AI assets
- document the offline delivery invariant and add regression coverage

## Why

Production offline testing showed that the cached game remained playable, but the lazy Sentry import was absent from the application shell and logged a failed module load. Vite only references entry chunks from HTML, so the previous HTML-based precache discovery could not see every lazy chunk.

## Validation

- `npm run check`
- production build with a Sentry DSN confirmed the lazy `prod-*.js` chunk is listed in `sw.js`
- 106 Rust tests, 360-game AI matrix, 141 Vitest tests, and 21 Chromium/WebKit Playwright tests passed
