### PR TITLE
Defer monitoring while offline

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ The browser cluster is the complete gameplay path. The Cloudflare Worker deliver
 - **Deterministic core** — starting-player and dice entropy can be injected; tests and simulations do not depend on ambient randomness.
 - **Validate every untrusted boundary** — persisted data, Worker requests, and WASM JSON are runtime values, not trusted TypeScript objects.
 - **Privacy by data minimization** — do not create or retain identifiers when anonymous lifecycle events are enough.
-- **Progressive resilience** — offline play, AI fallbacks, stale-response guards, request timeouts, and best-effort analytics keep optional failures out of the game loop.
+- **Progressive resilience** — offline play, online-only monitoring, AI fallbacks, stale-response guards, request timeouts, and best-effort analytics keep optional failures out of the game loop.
 
 ## Layers and dependency direction
 

--- a/src/lib/__tests__/observability.test.ts
+++ b/src/lib/__tests__/observability.test.ts
@@ -1,6 +1,17 @@
 import type { ErrorEvent } from '@sentry/browser';
-import { describe, expect, it } from 'vitest';
-import { sanitizeErrorEvent } from '../observability';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initializeObservability, sanitizeErrorEvent } from '../observability';
+
+vi.mock('@sentry/browser', () => ({
+  captureException: vi.fn(),
+  init: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+});
 
 describe('observability privacy filter', () => {
   it('removes identity, request data, query strings, and sensitive context', () => {
@@ -48,5 +59,21 @@ describe('observability privacy filter', () => {
     const event = { type: undefined, request: { url: 'not a URL' } } as ErrorEvent;
 
     expect(sanitizeErrorEvent(event).request).not.toHaveProperty('url');
+  });
+});
+
+describe('observability initialization', () => {
+  it('waits for connectivity before starting error monitoring', async () => {
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://public@example.invalid/1');
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    const Sentry = await import('@sentry/browser');
+
+    initializeObservability();
+    expect(Sentry.init).not.toHaveBeenCalled();
+
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    window.dispatchEvent(new Event('online'));
+
+    await vi.waitFor(() => expect(Sentry.init).toHaveBeenCalledOnce());
   });
 });

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -71,6 +71,10 @@ export function sanitizeErrorEvent(event: ErrorEvent): ErrorEvent {
 export function initializeObservability() {
   const dsn = import.meta.env.VITE_SENTRY_DSN;
   if (!dsn) return;
+  if (!navigator.onLine) {
+    window.addEventListener('online', initializeObservability, { once: true });
+    return;
+  }
 
   void loadSentry()
     .then(Sentry => {


### PR DESCRIPTION
## What changed

- defer Sentry initialization while the browser is offline
- initialize monitoring once connectivity returns
- document the online-only monitoring boundary
- add a regression test for offline startup and online recovery

## Why

The complete application now loads from the service-worker cache, including the lazy Sentry chunk. A fresh offline reload nevertheless caused Sentry to attempt ingestion immediately, producing an avoidable browser network error while leaving gameplay unaffected.

## Validation

- focused observability tests
- TypeScript type-check and ESLint
- documentation validation and formatting checks
- fresh production browser reproduction before the fix
