### PR TITLE
Harden model provenance paths

### DIFF
--- a/ml/scripts/model_provenance.py
+++ b/ml/scripts/model_provenance.py
@@ -5,6 +5,7 @@ import gzip
 import hashlib
 import json
 import math
+import os
 import re
 import sys
 from pathlib import Path
@@ -39,9 +40,11 @@ def canonical_hash(value: Any) -> str:
 
 
 def repository_path(path: Path) -> Path:
-    if path.is_absolute() or ".." in path.parts:
+    candidate = Path(os.path.realpath(REPOSITORY_ROOT / path))
+    repository_prefix = f"{REPOSITORY_ROOT}{os.sep}"
+    if candidate != REPOSITORY_ROOT and not str(candidate).startswith(repository_prefix):
         raise ValueError(f"path must stay inside the repository: {path}")
-    return REPOSITORY_ROOT / path
+    return candidate
 
 
 def display_path(path: Path) -> str:

--- a/ml/tests/test_model_provenance.py
+++ b/ml/tests/test_model_provenance.py
@@ -1,6 +1,8 @@
 import gzip
 import importlib.util
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -86,6 +88,18 @@ class ModelProvenanceTests(unittest.TestCase):
             model_provenance.repository_path(Path("../outside.json"))
         with self.assertRaisesRegex(ValueError, "inside the repository"):
             model_provenance.repository_path(Path("/tmp/outside.json"))
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks are unavailable")
+    def test_rejects_symlinks_outside_the_repository(self):
+        with tempfile.TemporaryDirectory(
+            dir=model_provenance.REPOSITORY_ROOT
+        ) as directory:
+            link = Path(directory) / "outside"
+            link.symlink_to(Path(tempfile.gettempdir()), target_is_directory=True)
+            relative_link = link.relative_to(model_provenance.REPOSITORY_ROOT)
+
+            with self.assertRaisesRegex(ValueError, "inside the repository"):
+                model_provenance.repository_path(relative_link / "outside.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Resolve provenance CLI paths before filesystem access.
- Reject repository-internal symlinks that escape the checkout.
- Cover relative traversal, absolute paths, and symlink traversal.

## Why

CodeQL correctly identified that the earlier lexical check did not account for symlinks.

## Validation

- `npm run check`
- 25 model/provenance tests, including the new symlink case