### PR TITLE
Improve AI documentation with diagrams and references

### DIFF
--- a/docs/AI-SYSTEM.md
+++ b/docs/AI-SYSTEM.md
@@ -2,33 +2,87 @@
 
 The game has three AI opponents, all written in Rust and compiled to WebAssembly. Search and inference run locally; there is no server-side AI service:
 
-- **Classic AI** — expectiminimax search with alpha-beta pruning and tunable evaluation parameters
+- **Classic AI** — [expectiminimax](https://en.wikipedia.org/wiki/Expectiminimax) search with [alpha-beta pruning](https://en.wikipedia.org/wiki/Alpha%E2%80%93beta_pruning) and tunable evaluation parameters
 - **ML AI** — a value + policy neural network trained from expectiminimax-labelled simulated games
 - **Oracle AI** — a compact value network distilled from the published strong solution of the game
 
-These are preserved as separate strategies: Classic searches at runtime, ML distils depth-limited Classic search, and Oracle approximates exact tablebase values. The public [AI guide](https://gameofur.org/ai) introduces the three approaches. The broad [AI matrix](./AI-MATRIX-RESULTS.md) compares research fixtures; [deployed matchup results](./AI-DEPLOYED-RESULTS.md) compare the three opponents available in the browser. For Oracle's research, design, and evidence, see [ORACLE-AI.md](./ORACLE-AI.md).
+The three are deliberately different answers to the same question. Classic thinks at runtime, searching the game tree on every turn. ML and Oracle think ahead of time: each plays with forward passes through a small network whose strength was fixed during training — ML distils depth-limited Classic search, Oracle approximates exact tablebase values.
+
+```mermaid
+flowchart LR
+    subgraph Ahead["Ahead of time"]
+        EVO["Evolutionary search<br/>tunes evaluation weights"]
+        SP["Depth-limited Classic search<br/>labels simulated games"]
+        TB["Solved-game tablebase<br/>exact win probabilities"]
+    end
+    subgraph Browser["In the browser"]
+        C["Classic AI<br/>depth-3 expectiminimax"]
+        M["ML AI<br/>value + policy network"]
+        O["Oracle AI<br/>distilled value network"]
+    end
+    EVO --> C
+    SP --> M
+    TB --> O
+    C --> W["One lazy Rust/WASM<br/>Web Worker"]
+    M --> W
+    O --> W
+```
+
+| Opponent | Decides a move by                                 | Teacher                              | Learned parameters   |
+| -------- | ------------------------------------------------- | ------------------------------------ | -------------------- |
+| Classic  | searching the live game tree to depth 3           | evolutionary tuning against defaults | 8 evaluation weights |
+| ML       | scoring successors with value and policy networks | depth-limited Classic search         | 164,040              |
+| Oracle   | valuing every legal successor's win probability   | the solved-game tablebase            | 29,057               |
+
+The public [AI guide](https://gameofur.org/ai) introduces the three approaches. The broad [AI matrix](./AI-MATRIX-RESULTS.md) compares research fixtures; [deployed matchup results](./AI-DEPLOYED-RESULTS.md) compare the three opponents available in the browser. For Oracle's research, design, and evidence, see [ORACLE-AI.md](./ORACLE-AI.md).
 
 Watch mode accepts an independent choice for each side from Classic, ML, and Oracle. The selected pairing uses the same typed mode policy as normal games and is retained across a page reload.
 
 ## Browser execution
 
-The UI never sends a complete `GameState` to AI code. The thin main-thread services share one lazily constructed `AIWorkerClient`, which sends a schema-validated `AIPosition`: seven squares per player, current player, and dice roll. The discriminated Worker protocol correlates each request by ID and times it out after 30 seconds. A timeout, transport failure, or invalid response restarts the Worker and rejects every pending request.
+The UI never sends a complete `GameState` to AI code. The thin main-thread services share one lazily constructed `AIWorkerClient` (`src/lib/ai-worker-client.ts`), which sends a schema-validated `AIPosition`: seven squares per player, current player, and dice roll. The discriminated Worker protocol correlates each request by ID and times it out after 30 seconds. A timeout, transport failure, or invalid response restarts the Worker and rejects every pending request.
 
-The single Worker lazily loads one Rust/WASM module and dispatches Classic, heuristic, ML, and Oracle requests. Learned weights are fetched inside the Worker: it prefers each gzip asset, uses streaming `DecompressionStream`, parses and validates model metadata, network dimensions, and exact weight counts, then loads the arrays into WASM. A failed, stale, or incompatible compressed artifact falls back to a freshly fetched uncompressed JSON compatibility asset. Search, inference, decompression, JSON parsing, and validation therefore stay off the UI thread.
+```mermaid
+sequenceDiagram
+    participant Store as Game store (UI thread)
+    participant Client as AIWorkerClient
+    participant Worker as Web Worker
+    participant WASM as Rust/WASM engines
+    Store->>Client: AIPosition
+    Client->>Worker: typed request, correlated by ID
+    Worker->>WASM: lazy-load module and weights, dispatch
+    WASM-->>Worker: move + diagnostics (JSON)
+    Worker-->>Client: schema-validated response
+    Client-->>Store: validated move
+    Note over Client,Worker: A timeout or invalid response restarts the Worker.<br/>The store falls back to a legal local move.
+```
+
+The single [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) (`src/lib/ai.worker.ts`) lazily loads one Rust/WASM module and dispatches Classic, heuristic, ML, and Oracle requests. Learned weights are fetched inside the Worker: it prefers each gzip asset, uses streaming [`DecompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream), parses and validates model metadata, network dimensions, and exact weight counts, then loads the arrays into WASM. A failed, stale, or incompatible compressed artifact falls back to a freshly fetched uncompressed JSON compatibility asset. Search, inference, decompression, JSON parsing, and validation therefore stay off the UI thread.
 
 The TypeScript and Rust rule implementations consume the same `test-fixtures/rules-conformance.json` cases. These fixtures cover entry, blocking, protected rosettes, captures, finishing, overshoot, and mirrored player tracks. Add a shared case whenever rule behavior changes.
 
 ## Classic AI
 
-Expectiminimax extends minimax to games with chance. The search alternates:
+[Expectiminimax](https://en.wikipedia.org/wiki/Expectiminimax) extends [minimax](https://en.wikipedia.org/wiki/Minimax) to games with chance. The mover already knows their own roll before choosing, so chance sits between turns: the search maximizes over the mover's choices, takes the expectation over the opponent's unknown roll, then minimizes over the opponent's replies.
 
-- **Min/Max nodes** for the players' choices
+```mermaid
+flowchart TD
+    MAX["Max — choose the mover's move<br/>(current roll is known)"] --> EXP(("Expectation over<br/>the opponent's roll"))
+    EXP -->|"0 · 1/16"| P["Turn passes"]
+    EXP -->|"1 · 4/16"| M1["Min — opponent replies"]
+    EXP -->|"2 · 6/16"| M2["Min — opponent replies"]
+    EXP -->|"3 · 4/16"| M3["Min — opponent replies"]
+    EXP -->|"4 · 1/16"| M4["Min — opponent replies"]
+    M2 --> NEXT["… deeper expectation<br/>and max nodes"]
+```
+
+- **Min/Max nodes** for the players' choices; node type follows the rules engine's turn logic, so a rosette landing produces consecutive levels for the same side
 - **Expectation nodes** for the dice roll, weighting child values by probability
-- **Alpha-beta pruning** to skip branches that cannot affect the result
+- **[Alpha-beta pruning](https://en.wikipedia.org/wiki/Alpha%E2%80%93beta_pruning)** to skip branches that cannot affect the result
 
 ### Dice probabilities
 
-Four binary dice give a roll of 0–4:
+Four binary dice give a roll of 0–4 — a [binomial distribution](https://en.wikipedia.org/wiki/Binomial_distribution) centred on 2:
 
 | Roll | Probability |
 | ---- | ----------- |
@@ -42,13 +96,13 @@ Four binary dice give a roll of 0–4:
 
 The browser Classic AI searches to **depth 3** (`BROWSER_CLASSIC_AI_DEPTH`). This keeps the deliberate search opponent responsive in the Worker. The normal AI matrix benchmarks depths 1–3; slow tests add depth 4 for research only.
 
-The optimized browser instance retains a transposition table across requests. A position hash includes all seven pieces for both players, current player, and genetic parameters. The table is bounded at 50,000 entries and clears before inserting beyond the ceiling, preventing an unbounded long-lived Worker cache.
+The optimized browser instance retains a [transposition table](https://www.chessprogramming.org/Transposition_Table) across requests. A position hash includes all seven pieces for both players, current player, and genetic parameters. The table is bounded at 50,000 entries and clears before inserting beyond the ceiling, preventing an unbounded long-lived Worker cache.
 
 ### Evaluation parameters
 
 The evaluation function is driven by a set of weights (`GeneticParams` in `worker/rust_ai_core/src/genetic_params.rs`): win score, finished-piece value, position weight, safety, rosette control, advancement, capture, and center-lane bonuses.
 
-An evolutionary search (`cargo run --release --bin evolve_params`) tunes these against the defaults and writes an optimized set to `ml/data/genetic_params/evolved.json`. The Rust build embeds that JSON for native and WASM use; malformed embedded data falls back to the built-in defaults. The evolved set is:
+A [genetic algorithm](https://en.wikipedia.org/wiki/Genetic_algorithm) (`cargo run --release --bin evolve_params`) tunes these against the defaults and writes an optimized set to `ml/data/genetic_params/evolved.json`. The Rust build embeds that JSON for native and WASM use; malformed embedded data falls back to the built-in defaults. The evolved set is:
 
 ```json
 {
@@ -76,16 +130,34 @@ The search runs 50 generations of 50 individuals with 100 games per evaluation. 
 
 ### Architecture
 
+```mermaid
+flowchart LR
+    F["150-feature<br/>state vector"] --> V["Value MLP<br/>256 → 128 → 64 → 32"]
+    F --> PN["Policy MLP<br/>256 → 128 → 64 → 32"]
+    V --> VO["1 tanh unit<br/>normalized evaluation"]
+    PN --> PO["7-way softmax<br/>piece choice"]
+```
+
 - **Input**: the same 150-feature game-state vector is supplied to both networks
-- **Networks**: independent value and policy MLPs, each with 256 → 128 → 64 → 32 hidden units (ReLU)
+- **Networks**: independent value and policy [MLPs](https://en.wikipedia.org/wiki/Multilayer_perceptron), each with 256 → 128 → 64 → 32 hidden units (ReLU), 164,040 parameters in total
 - **Outputs**: the value network emits 1 tanh unit estimating normalized expectiminimax evaluation; the policy network emits a 7-way softmax over piece choices
 - Move scoring combines the successor value from the mover's perspective, current policy probability, and fixed finish/capture/rosette bonuses
 
-The architecture is defined in `ml/config/training.json` and `worker/rust_ai_core/src/features.rs`.
+The value + policy decomposition is the same one popularized by [AlphaGo Zero](https://www.nature.com/articles/nature24270), with expectiminimax standing in as the teacher instead of tree-search reinforcement learning. The architecture is defined in `ml/config/training.json` and `worker/rust_ai_core/src/features.rs`.
 
 ### Training
 
-The data generator uses depth-limited Classic expectiminimax as its only teacher; it does not use the Oracle tablebase or solved-game model. It alternates the starting player between games, and a zero roll or blocked position passes the turn exactly as it does in the game. Each playable position is searched once. The best score becomes a normalized Player 2 value target, forced moves retain their searched value, and equally scored piece choices share the policy target. After recording the label, ten per cent of rollouts take a different legal move so the corpus includes recovery positions. Runtime move selection converts successor values back to the mover's perspective before ranking legal moves.
+```mermaid
+flowchart LR
+    GEN["Rust game generator with<br/>depth-limited Classic search"] --> LAB["Labelled positions:<br/>value + policy targets"]
+    LAB --> TR["PyTorch (GPU) or<br/>Rust (CPU) trainer"]
+    TR --> SRC["Versioned source model"]
+    SRC --> PUB["npm run load:ml-weights<br/>validate + publish"]
+    PUB --> ASSET["Public JSON +<br/>deterministic gzip"]
+    ASSET --> WK["Web Worker fetch,<br/>validate, load into WASM"]
+```
+
+The data generator uses depth-limited Classic expectiminimax as its only teacher; it does not use the Oracle tablebase or solved-game model. It alternates the starting player between games, and a zero roll or blocked position passes the turn exactly as it does in the game. Each playable position is searched once. The best score becomes a normalized Player 2 value target, forced moves retain their searched value, and equally scored piece choices share the policy target. After recording the label, ten per cent of rollouts take a different legal move so the corpus includes recovery positions. Runtime move selection converts successor values back to the mover's perspective before ranking legal moves. Two training backends share the same presets:
 
 | Backend | Hardware                      | Notes                           |
 | ------- | ----------------------------- | ------------------------------- |
@@ -114,7 +186,7 @@ See [DEVELOPMENT.md](./DEVELOPMENT.md) and [ml/README.md](../ml/README.md) for t
 
 Oracle is a `32 → 128 → 128 → 64 → 1` ReLU value network with a tanh output. Its 32-value canonical input describes current-player and opponent occupancy, reserve counts, and finished counts. It deliberately omits colour identity, dice, piece indices, handcrafted scores, duplicates, and padding.
 
-The teacher is the 16-bit tablebase published with the 2025 strong solution of the Finkel ruleset. Training samples exact pre-roll win probabilities from that external 827 MB artifact; the tablebase never ships to browsers. The production run uses two million training positions, 100,000 validation positions, and 100,000 disjoint test positions. The pinned configuration, source and tablebase hashes, sample identity, candidate results, and held-out metrics are stored with the model.
+The teacher is the 16-bit tablebase published with the [2025 strong solution](https://royalur.net/blog/solved) of the Finkel ruleset. Training samples exact pre-roll win probabilities from that external 827 MB artifact; the tablebase never ships to browsers. The production run uses two million training positions, 100,000 validation positions, and 100,000 disjoint test positions. The pinned configuration, source and tablebase hashes, sample identity, candidate results, and held-out metrics are stored with the model.
 
 At runtime Rust enumerates legal moves with the rules engine, evaluates each successor, and converts the successor's current-player probability back to the mover's perspective. A rosette retains the same perspective; a normal turn change uses `1 - V`; an immediate win is `1`. This keeps move legality and turn semantics in the rules engine and avoids a policy head or post-training move bonuses.
 
@@ -129,3 +201,11 @@ npm run test:ai-comparison:fast            # quick matrix (10 games per match)
 npm run test:ai-comparison:comprehensive   # 100 games per match, plus slow tests
 npm run test:ai-deployed                    # 400 games per browser-opponent pairing
 ```
+
+## Further reading
+
+- [Expectiminimax](https://en.wikipedia.org/wiki/Expectiminimax) — minimax over game trees that contain chance nodes
+- [Ballard, _The \*-minimax search procedure for trees containing chance nodes_ (1983)](https://doi.org/10.1016/s0004-3702%2883%2980015-0) — pruning through expectation nodes
+- [Transposition tables — Chess Programming Wiki](https://www.chessprogramming.org/Transposition_Table) — caching searched positions by hash
+- [Silver et al., _Mastering the game of Go without human knowledge_ (2017)](https://www.nature.com/articles/nature24270) — the value + policy network pattern
+- [Strongly Solving the Royal Game of Ur](https://royalur.net/blog/solved) — the solved game Oracle is distilled from; full sources in [ORACLE-AI.md](./ORACLE-AI.md#sources)

--- a/docs/ORACLE-AI.md
+++ b/docs/ORACLE-AI.md
@@ -28,7 +28,7 @@ flowchart LR
 
 ## Why the tablebase is suitable
 
-Padraig Lamont and Jeroen Olieslagers strongly solved the Finkel ruleset in 2025 using Bellman value iteration. Their artifact stores the light-player win probability for every reachable pre-roll state. Player symmetry reduces roughly 276 million reachable states to **137,892,016 stored entries**.
+Padraig Lamont and Jeroen Olieslagers [strongly solved](https://en.wikipedia.org/wiki/Solved_game) the Finkel ruleset in 2025 using [Bellman value iteration](https://en.wikipedia.org/wiki/Bellman_equation). Their artifact stores the light-player win probability for every reachable pre-roll state. Player symmetry reduces roughly 276 million reachable states to **137,892,016 stored entries**.
 
 The tablebase header declares the configuration used by this application: a standard board, Bell's path, seven pieces, four binary dice, safe rosettes, extra rolls on rosettes, and no extra roll for captures. The trainer rejects different settings and pins the 827,352,312-byte artifact by SHA-256:
 
@@ -68,6 +68,11 @@ The schema contains no colour identity, dice roll, handcrafted strategy score, d
 
 The network is `32 → 128 → 128 → 64 → 1`, with ReLU hidden layers and a tanh output mapped to a probability. It has 29,057 learned parameters. This shape was selected by the pilot, not chosen after the production result was known.
 
+```mermaid
+flowchart LR
+    IN["32 canonical<br/>features"] --> H1["128<br/>ReLU"] --> H2["128<br/>ReLU"] --> H3["64<br/>ReLU"] --> OUT["1 tanh →<br/>win probability"]
+```
+
 ## Move selection
 
 For a known roll, Rust enumerates every legal move and evaluates its resulting pre-roll state:
@@ -75,6 +80,20 @@ For a known roll, Rust enumerates every legal move and evaluates its resulting p
 - An immediate winning move has value `1`.
 - After a normal move, the opponent becomes current, so the mover's value is `1 - V(successor)`.
 - After landing on a rosette, the mover stays current, so the value is `V(successor)`.
+
+```mermaid
+flowchart TD
+    ROLL["Known roll"] --> ENUM["Rules engine enumerates<br/>every legal move"]
+    ENUM --> SUCC["Successor pre-roll position"]
+    SUCC --> WIN{"Immediate win?"}
+    WIN -->|Yes| ONE["Value = 1"]
+    WIN -->|No| ROS{"Landed on a rosette?"}
+    ROS -->|"Yes — mover stays current"| SAME["Value = V(successor)"]
+    ROS -->|"No — turn passes"| FLIP["Value = 1 − V(successor)"]
+    ONE --> PICK["Highest value wins"]
+    SAME --> PICK
+    FLIP --> PICK
+```
 
 The highest value wins. Equivalent reserve pieces produce equivalent successors, with the lowest stable piece index as the deterministic tie-break. No capture, finish, rosette, or policy bonus is added after training.
 
@@ -93,11 +112,11 @@ npm run train:oracle:production
 2. memory-maps the file and samples without replacement with seed `20250715`;
 3. partitions that sample into disjoint train, validation, and test sets;
 4. cross-checks vectorized feature extraction against the reference decoder;
-5. trains every configured architecture, loss, and seed with early stopping and best-checkpoint restoration;
+5. trains every configured architecture, loss, and seed with [early stopping](https://en.wikipedia.org/wiki/Early_stopping) and best-checkpoint restoration;
 6. selects the lowest validation MAE and evaluates the test set once; and
 7. exports matrices in Rust's expected order with configuration, code, tablebase, sample, and source identities.
 
-The pilot uses 200,000 training, 25,000 validation, and 25,000 test positions across two network shapes, MSE and Huber loss, and two seeds. It selected the current architecture with Huber loss and seed 42. Its held-out test MAE was **0.00658** and p95 absolute error was **0.01672**. In a 900-game exploratory matrix it averaged **87.2%** against the other nine engines; that small stochastic run justified scaling but is not the final comparison.
+The pilot uses 200,000 training, 25,000 validation, and 25,000 test positions across two network shapes, MSE and [Huber loss](https://en.wikipedia.org/wiki/Huber_loss), and two seeds. It selected the current architecture with Huber loss and seed 42. Its held-out test MAE was **0.00658** and p95 absolute error was **0.01672**. In a 900-game exploratory matrix it averaged **87.2%** against the other nine engines; that small stochastic run justified scaling but is not the final comparison.
 
 The production preset uses 2,000,000 training, 100,000 validation, and 100,000 test positions, with three seeds. The wrapper uses `caffeinate` on macOS so a long run is not interrupted by system sleep.
 
@@ -157,3 +176,4 @@ The model runs entirely in the browser. No position, move, or personal result is
 - [RoyalUr solved-model repository](https://huggingface.co/sothatsit/RoyalUrModels)
 - [RoyalUr Python reference implementation](https://github.com/RosetteGames/royalur-python)
 - [Distilling the Knowledge in a Neural Network](https://arxiv.org/abs/1503.02531)
+- [Solved game](https://en.wikipedia.org/wiki/Solved_game) — what ultra-weak, weak, and strong solutions claim

--- a/ml/README.md
+++ b/ml/README.md
@@ -39,7 +39,7 @@ The Oracle trainer deliberately uses this fixed scratch path and a fixed reposit
 
 ## Prerequisites
 
-- **uv** for the locked Python training environment
+- **[uv](https://docs.astral.sh/uv/)** for the locked Python training environment
 - **Python 3.12.13**, selected from `ml/.python-version` by uv
 - **Rust & Cargo** (data generation, and the CPU backend)
 - **GPU** for PyTorch: Apple Metal (MPS) or NVIDIA CUDA
@@ -97,6 +97,17 @@ npm run load:ml-weights
 Genetic parameters for the Classic AI are evolved separately — see [AI-SYSTEM.md](../docs/AI-SYSTEM.md#evaluation-parameters).
 
 ## Reproducibility and model promotion
+
+Both learned models promote through the same shape: a versioned source model, provenance validation, byte-identical public artifacts, and a manifest that CI re-verifies.
+
+```mermaid
+flowchart LR
+    TRAIN["Training run"] --> SRC["Versioned source model<br/>ml/data/weights/"]
+    SRC --> VAL["Provenance validation"]
+    VAL --> PUB["Byte-identical JSON +<br/>deterministic gzip assets"]
+    PUB --> MAN["Model manifest"]
+    MAN --> VER["npm run test:model-provenance<br/>re-verifies in CI"]
+```
 
 ### Classic-distilled ML
 


### PR DESCRIPTION
Improves the public AI documentation while keeping the existing voice and facts:

**docs/AI-SYSTEM.md**
- Adds an opponent-overview mermaid diagram (training-time teachers → browser engines → shared Worker) and a three-way comparison table (decision method, teacher, parameter counts)
- Adds a Worker sequence diagram, an expectiminimax tree diagram, an ML architecture diagram, and a training/promotion pipeline diagram
- Links external references throughout (expectiminimax, alpha-beta, transposition tables, binomial dice distribution, MLPs, MDN Worker/DecompressionStream) and adds a curated Further reading section (Ballard 1983, AlphaGo Zero, the solved game)

**docs/ORACLE-AI.md**
- Adds a network-shape diagram and a move-selection value-conversion diagram
- Links solved game, Bellman value iteration, Huber loss, and early stopping; adds a Sources entry

**ml/README.md**
- Adds a shared model-promotion pipeline diagram and links uv

All facts verified against the current code and the Classic-distilled v6 model metadata (164,040 ML parameters confirmed from the promoted weights). Every mermaid block was rendered and checked; `npm run check:docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)