### PR TITLE
Make PWA updates reliable on resume

### DIFF
--- a/e2e/browser-quality.spec.ts
+++ b/e2e/browser-quality.spec.ts
@@ -161,7 +161,9 @@ test('keeps the mobile opening compact and player panels stable between turns', 
 test('AI article explains the opponents and returns to the game', async ({ page }) => {
   await page.goto('/ai');
 
-  await expect(page).toHaveTitle('About the AIs · Royal Game of Ur');
+  await expect(page).toHaveTitle(
+    "The world's oldest board game was solved last year · Royal Game of Ur"
+  );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     'href',
     'https://gameofur.org/ai'
@@ -170,13 +172,14 @@ test('AI article explains the opponents and returns to the game', async ({ page 
   await expect(
     page.getByRole('heading', {
       level: 1,
-      name: 'Three different ways to play Ur',
+      name: "The world's oldest board game was solved last year. I only just found out.",
     })
   ).toBeVisible();
   await expect(page.getByRole('table', { name: 'Deployed AI win rates' })).toContainText('85.0%');
-  await expect(
-    page.getByRole('link', { name: 'Current browser-opponent results' })
-  ).toHaveAttribute('rel', /noopener/);
+  await expect(page.getByRole('link', { name: 'AI-SYSTEM.md' })).toHaveAttribute(
+    'rel',
+    /noopener/
+  );
 
   await page.getByRole('link', { name: 'Play the game' }).click();
   await expect(page.getByTestId('ai-model-selection')).toBeVisible();
@@ -231,7 +234,10 @@ test.describe('offline service worker', () => {
     await context.setOffline(true);
     try {
       await page.reload({ waitUntil: 'domcontentloaded' });
-      expect(failedRequests).toEqual([]);
+      // The update lifecycle deliberately probes the worker entry point with a
+      // no-store request. That best-effort request may fail after the browser
+      // has entered offline mode; the cached application shell still must not.
+      expect(failedRequests.filter(path => path !== '/sw.js')).toEqual([]);
       await expect(page.getByRole('heading', { level: 1, name: 'Royal Game of Ur' })).toBeVisible();
       await expect(page.getByTestId('ai-model-selection')).toBeVisible();
     } finally {

--- a/e2e/browser-quality.spec.ts
+++ b/e2e/browser-quality.spec.ts
@@ -161,9 +161,7 @@ test('keeps the mobile opening compact and player panels stable between turns', 
 test('AI article explains the opponents and returns to the game', async ({ page }) => {
   await page.goto('/ai');
 
-  await expect(page).toHaveTitle(
-    "The world's oldest board game was solved last year · Royal Game of Ur"
-  );
+  await expect(page).toHaveTitle('About the AIs · Royal Game of Ur');
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     'href',
     'https://gameofur.org/ai'
@@ -172,14 +170,13 @@ test('AI article explains the opponents and returns to the game', async ({ page 
   await expect(
     page.getByRole('heading', {
       level: 1,
-      name: "The world's oldest board game was solved last year. I only just found out.",
+      name: 'Three different ways to play Ur',
     })
   ).toBeVisible();
   await expect(page.getByRole('table', { name: 'Deployed AI win rates' })).toContainText('85.0%');
-  await expect(page.getByRole('link', { name: 'AI-SYSTEM.md' })).toHaveAttribute(
-    'rel',
-    /noopener/
-  );
+  await expect(
+    page.getByRole('link', { name: 'Current browser-opponent results' })
+  ).toHaveAttribute('rel', /noopener/);
 
   await page.getByRole('link', { name: 'Play the game' }).click();
   await expect(page.getByTestId('ai-model-selection')).toBeVisible();

--- a/public/_headers
+++ b/public/_headers
@@ -6,3 +6,18 @@
   Strict-Transport-Security: max-age=31536000
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
+
+/sw.js
+  Cache-Control: no-store
+
+/
+  Cache-Control: no-cache, must-revalidate
+
+/*.html
+  Cache-Control: no-cache, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/wasm/*
+  Cache-Control: no-cache, must-revalidate

--- a/src/components/ServiceWorkerUpdate.tsx
+++ b/src/components/ServiceWorkerUpdate.tsx
@@ -1,19 +1,29 @@
 import { useEffect, useState } from 'react';
 import { LoaderCircle, RefreshCw } from 'lucide-react';
+import {
+  activateWaitingServiceWorker,
+  checkForServiceWorkerUpdate,
+  installUpdateCheckTriggers,
+  shouldCheckForUpdate,
+} from '../lib/service-worker-update';
 
 export default function ServiceWorkerUpdate() {
   const [waiting, setWaiting] = useState<ServiceWorker | null>(null);
   const [isApplying, setIsApplying] = useState(false);
+  const [isDeferred, setIsDeferred] = useState(false);
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
     let active = true;
+    let checking = false;
+    let lastCheckAt = 0;
     let registration: ServiceWorkerRegistration | undefined;
     let installingWorker: ServiceWorker | null = null;
 
     const handleStateChange = () => {
       if (active && installingWorker?.state === 'installed' && navigator.serviceWorker.controller) {
         setWaiting(installingWorker);
+        setIsDeferred(false);
       }
     };
 
@@ -23,6 +33,34 @@ export default function ServiceWorkerUpdate() {
       installingWorker?.addEventListener('statechange', handleStateChange);
     };
 
+    const checkForUpdate = async (force = false) => {
+      if (
+        !active ||
+        checking ||
+        !registration ||
+        !navigator.onLine ||
+        document.visibilityState !== 'visible'
+      ) {
+        return;
+      }
+      const now = Date.now();
+      if (!force && !shouldCheckForUpdate(now, lastCheckAt)) return;
+
+      checking = true;
+      lastCheckAt = now;
+      try {
+        await checkForServiceWorkerUpdate({registration});
+        if (registration.waiting) setWaiting(registration.waiting);
+      } catch {
+        // Update discovery is best-effort; normal app requests surface connectivity.
+      } finally {
+        checking = false;
+      }
+    };
+    const removeTriggers = installUpdateCheckTriggers({
+      check: () => void checkForUpdate(),
+    });
+
     void navigator.serviceWorker
       .register('/sw.js')
       .then(async currentRegistration => {
@@ -30,12 +68,13 @@ export default function ServiceWorkerUpdate() {
         registration = currentRegistration;
         if (registration.waiting) setWaiting(registration.waiting);
         registration.addEventListener('updatefound', handleUpdateFound);
-        await registration.update();
+        await checkForUpdate(true);
       })
       .catch(error => console.warn('Service worker registration failed:', error));
 
     return () => {
       active = false;
+      removeTriggers();
       registration?.removeEventListener('updatefound', handleUpdateFound);
       installingWorker?.removeEventListener('statechange', handleStateChange);
     };
@@ -45,18 +84,23 @@ export default function ServiceWorkerUpdate() {
     if (!waiting || isApplying) return;
 
     setIsApplying(true);
-    const reload = () => window.location.reload();
-    const fallback = window.setTimeout(reload, 4_000);
-    const handleControllerChange = () => {
-      window.clearTimeout(fallback);
-      reload();
-    };
-
-    navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange, { once: true });
-    waiting.postMessage({ type: 'SKIP_WAITING' });
+    activateWaitingServiceWorker({worker: waiting});
   };
 
   if (!waiting) return null;
+
+  if (isDeferred) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsDeferred(false)}
+        className="surface-panel fixed bottom-4 right-4 z-[10000] rounded-full border-brass/35 px-4 py-2 text-sm font-semibold text-brass-light shadow-xl shadow-black/25"
+        aria-label="Update ready. Show update options"
+      >
+        Update ready
+      </button>
+    );
+  }
 
   return (
     <aside
@@ -87,7 +131,7 @@ export default function ServiceWorkerUpdate() {
           type="button"
           onClick={() => {
             setIsApplying(false);
-            setWaiting(null);
+            setIsDeferred(true);
           }}
           disabled={isApplying}
           className="h-9 shrink-0 rounded-lg px-1.5 text-sm font-medium text-bone-muted transition-colors hover:text-bone disabled:cursor-wait disabled:opacity-60"

--- a/src/lib/__tests__/service-worker-update.test.ts
+++ b/src/lib/__tests__/service-worker-update.test.ts
@@ -1,0 +1,69 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {
+  activateWaitingServiceWorker,
+  checkForServiceWorkerUpdate,
+  installUpdateCheckTriggers,
+  shouldCheckForUpdate,
+} from '../service-worker-update';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('service worker updates', () => {
+  it('debounces frequent checks', () => {
+    expect(shouldCheckForUpdate(1_000, 0)).toBe(true);
+    expect(shouldCheckForUpdate(61_000, 1_000)).toBe(true);
+    expect(shouldCheckForUpdate(60_999, 1_000)).toBe(false);
+  });
+
+  it('bypasses browser caches before updating', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response('', {status: 200}));
+    const update = vi.fn().mockResolvedValue(undefined);
+
+    await checkForServiceWorkerUpdate({
+      registration: {update} as unknown as ServiceWorkerRegistration,
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      '/sw.js',
+      expect.objectContaining({cache: 'no-store'})
+    );
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('checks when a visible app returns to the foreground', () => {
+    const check = vi.fn();
+    Object.defineProperty(document, 'visibilityState', {value: 'visible', configurable: true});
+    Object.defineProperty(navigator, 'onLine', {value: true, configurable: true});
+    const cleanup = installUpdateCheckTriggers({check});
+
+    window.dispatchEvent(new Event('pageshow'));
+    window.dispatchEvent(new Event('online'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(check).toHaveBeenCalledTimes(3);
+    cleanup();
+  });
+
+  it('activates the selected waiting worker and reloads', () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const worker = new EventTarget() as ServiceWorker;
+    const serviceWorkerContainer = new EventTarget();
+    Object.defineProperty(worker, 'state', {value: 'installed', configurable: true});
+    worker.postMessage = vi.fn();
+
+    activateWaitingServiceWorker({
+      worker,
+      reload,
+      serviceWorkerContainer,
+    });
+    expect(worker.postMessage).toHaveBeenCalledWith({type: 'SKIP_WAITING'});
+
+    vi.advanceTimersByTime(4_000);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/service-worker-update.ts
+++ b/src/lib/service-worker-update.ts
@@ -1,0 +1,84 @@
+export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+export const UPDATE_CHECK_COOLDOWN_MS = 60 * 1000;
+export const UPDATE_RELOAD_FALLBACK_MS = 4 * 1000;
+
+type UpdateCheckOptions = {
+  registration: ServiceWorkerRegistration;
+  fetcher?: typeof fetch;
+};
+
+type UpdateTriggerOptions = {
+  check: () => void;
+  intervalMs?: number;
+};
+
+type ActivateUpdateOptions = {
+  worker: ServiceWorker;
+  reload?: () => void;
+  serviceWorkerContainer?: Pick<ServiceWorkerContainer, 'addEventListener' | 'removeEventListener'>;
+};
+
+export const shouldCheckForUpdate = (
+  now: number,
+  lastCheckAt: number,
+  cooldownMs = UPDATE_CHECK_COOLDOWN_MS
+) => lastCheckAt === 0 || now - lastCheckAt >= cooldownMs;
+
+export const checkForServiceWorkerUpdate = async ({
+  registration,
+  fetcher = fetch,
+}: UpdateCheckOptions): Promise<void> => {
+  const response = await fetcher('/sw.js', {
+    cache: 'no-store',
+    headers: {'cache-control': 'no-cache'},
+  });
+  if (!response.ok) throw new Error('Service worker is unavailable');
+  await registration.update();
+};
+
+export const installUpdateCheckTriggers = ({
+  check,
+  intervalMs = UPDATE_CHECK_INTERVAL_MS,
+}: UpdateTriggerOptions) => {
+  const checkWhenVisible = () => {
+    if (document.visibilityState === 'visible' && navigator.onLine) check();
+  };
+  const intervalId = window.setInterval(checkWhenVisible, intervalMs);
+
+  document.addEventListener('visibilitychange', checkWhenVisible);
+  window.addEventListener('focus', checkWhenVisible);
+  window.addEventListener('online', checkWhenVisible);
+  window.addEventListener('pageshow', checkWhenVisible);
+
+  return () => {
+    window.clearInterval(intervalId);
+    document.removeEventListener('visibilitychange', checkWhenVisible);
+    window.removeEventListener('focus', checkWhenVisible);
+    window.removeEventListener('online', checkWhenVisible);
+    window.removeEventListener('pageshow', checkWhenVisible);
+  };
+};
+
+export const activateWaitingServiceWorker = ({
+  worker,
+  reload = () => window.location.reload(),
+  serviceWorkerContainer = navigator.serviceWorker,
+}: ActivateUpdateOptions) => {
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    window.clearTimeout(fallback);
+    serviceWorkerContainer.removeEventListener('controllerchange', finish);
+    worker.removeEventListener('statechange', onStateChange);
+    reload();
+  };
+  const onStateChange = () => {
+    if (worker.state === 'activated') finish();
+  };
+  const fallback = window.setTimeout(finish, UPDATE_RELOAD_FALLBACK_MS);
+
+  serviceWorkerContainer.addEventListener('controllerchange', finish);
+  worker.addEventListener('statechange', onStateChange);
+  worker.postMessage({type: 'SKIP_WAITING'});
+};


### PR DESCRIPTION
## Summary
- check for service-worker updates on resume, focus, online and pageshow with a cooldown
- bypass browser caches when probing the worker
- make the waiting-worker activation/reload path deterministic
- serve app shell and worker discovery resources with safe cache headers
- cover update lifecycle and offline/update browser flows

## Verification
- 4 focused lifecycle tests passed
- production build passed
- 9 browser-quality tests passed, including offline reload and waiting-worker activation

Supersedes #35, whose branch acquired unrelated AI article work while checks were running.